### PR TITLE
fix sync with mac os x el capitain

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -3,9 +3,9 @@ location PATHTOCHANGE {
        if ($scheme = http) {
             rewrite ^ https://$server_name$request_uri? permanent;
        }
-       
+
        index index.php;
-       
+
        location ~ ^(.+\.php)(.*)$ {
            fastcgi_split_path_info ^(.+\.php)(.*)$;
            fastcgi_pass unix:/var/run/php5-fpm.sock;
@@ -13,9 +13,14 @@ location PATHTOCHANGE {
            fastcgi_param PATH_INFO       $fastcgi_path_info;
            fastcgi_param SCRIPT_FILENAME $request_filename;
        }
-       #rewrite ~ ^/.well-known/caldav PATHTOCHANGE/cal.php redirect;
-       #rewrite ~ ^/.well-known/carddav PATHTOCHANGE/card.php redirect;
 }
+
+location /.well-known/carddav {
+       rewrite ^(.*)$ PATHTOCHANGE/card.php redirect;
+ }
+ location /.well-known/caldav {
+   rewrite ^(.*)$ PATHTOCHANGE/cal.php redirect;
+ }
 
 location ~ ^PATHTOCHANGE/(\.ht|Core|Specific) {
        deny all;


### PR DESCRIPTION
I just made a change to fix syncing with mac os el capitain.
The client try the url /.well-known (so not in baikal location), if it doesn't exists the synchronization fail.

It is fix by adding the redirect into baikal nginx conf file.

