### PR TITLE
Fix redirection of .well-known URLs

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -9,9 +9,9 @@ location PATHTOCHANGE {
        location ~ ^(.+\.php)(.*)$ {
            fastcgi_split_path_info ^(.+\.php)(.*)$;
            fastcgi_pass unix:/var/run/php5-fpm.sock;
-           fastcgi_param SCRIPT_FILENAME  $document_root/$fastcgi_script_name;
-           fastcgi_param PATH_INFO $fastcgi_path_info;
            include fastcgi_params;
+           fastcgi_param PATH_INFO       $fastcgi_path_info;
+           fastcgi_param SCRIPT_FILENAME $request_filename;
        }
        #rewrite ~ ^/.well-known/caldav PATHTOCHANGE/cal.php redirect;
        #rewrite ~ ^/.well-known/carddav PATHTOCHANGE/card.php redirect;

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,5 +1,5 @@
 location PATHTOCHANGE {
-       alias ALIASTOCHANGE;
+       alias ALIASTOCHANGE/;
        if ($scheme = http) {
             rewrite ^ https://$server_name$request_uri? permanent;
        }

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
         "en": "Lightweight CalDAV+CardDAV server",
         "fr": "Serveur CalDAV+CardDAV léger"
     },
-    "url": "https://github.com/julienmalik",
+    "url": "http://baikal-server.com/",
     "maintainer": {
         "name": "julien",
         "email": "julien.malik@paraiso.me"

--- a/scripts/install
+++ b/scripts/install
@@ -21,8 +21,8 @@ final_path=/var/www/baikal
 sudo mkdir -p $final_path
 sudo cp -a ../sources/* $final_path
 sudo chown -R www-data: $final_path
-sudo su -c "curl -sS https://getcomposer.org/installer | php -- --install-dir=$final_path" www-data
-sudo su -c "cd $final_path && php composer.phar install" www-data
+sudo su -c "curl -sS https://getcomposer.org/installer | php -- --install-dir=$final_path" -s /bin/sh www-data
+sudo su -c "cd $final_path && php composer.phar install" -s /bin/sh www-data
 sudo rm $final_path/composer*
 
 db_pwd=$(dd if=/dev/urandom bs=1 count=200 2> /dev/null | tr -c -d '[A-Za-z0-9]' | sed -n 's/\(.\{24\}\).*/\1/p')

--- a/scripts/install
+++ b/scripts/install
@@ -31,7 +31,7 @@ sudo yunohost app initdb $db_user -p $db_pwd -s $(readlink -e ../sources/Core/Re
 sudo yunohost app setting baikal mysqlpwd -v $db_pwd
 sed -i "s@YNH_TIMEZONE@$(cat /etc/timezone)@g" ../conf/config.php
 sed -i "s@YNH_ADMIN_PASSWORDHASH@$(echo -n admin:BaikalDAV:$password | md5sum | cut -d ' ' -f 1)@g" ../conf/config.php
-sudo yunohost app setting baikal password -v $password
+sudo yunohost app setting baikal password -v "$password"
 
 sed -i "s@YNH_LOCATION@$path@g" ../conf/config.system.php
 sed -i "s@YNH_DBNAME@$db_user@g" ../conf/config.system.php

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -18,8 +18,8 @@ sudo rm -rf /var/www/baikal
 sudo mkdir -p $final_path
 sudo cp -a ../sources/* $final_path
 sudo chown -R www-data: $final_path
-sudo su -c "curl -sS https://getcomposer.org/installer | php -- --install-dir=$final_path" www-data
-sudo su -c "cd $final_path && php composer.phar install" www-data
+sudo su -c "curl -sS https://getcomposer.org/installer | php -- --install-dir=$final_path" -s /bin/sh www-data
+sudo su -c "cd $final_path && php composer.phar install" -s /bin/sh www-data
 sudo rm $final_path/composer*
 
 db_pwd=$(sudo yunohost app setting baikal mysqlpwd)


### PR DESCRIPTION
Hi,

I manage to fix the redirection of ".well-known" URLs for baikal using the redirection_urls setting of SSOwat.
The original RewriteRules in NGinX settings couldn't work well because they were declared inside the /baikal location.

You'll find above the pull-request that i made from my personal Gogs repo.



The following changes since commit d102cfa03494d798ae8434824e153d542567fda9:

  Merge pull request #15 from Psycojoker/patch-1 (2016-03-29 09:13:59 +0200)

are available in the git repository at:

  https://testynh.nohost.me/gogs/phiwui/baikal_ynh.git

for you to fetch changes up to b4dc06068b009f9e7c38d567e36b1f44a343450c:

  Fix redirection of .well-known URLs (2016-04-14 01:52:57 +0200)

----------------------------------------------------------------
phiwui (1):
      Fix redirection of .well-known URLs

 conf/nginx.conf | 2 --
 scripts/install | 3 +++
 2 files changed, 3 insertions(+), 2 deletions(-)
